### PR TITLE
Resilient indexing and aggregation services

### DIFF
--- a/async_ipfshttpclient/main.py
+++ b/async_ipfshttpclient/main.py
@@ -29,7 +29,7 @@ class AsyncIPFSClient:
             )
             self._client = AsyncClient(
                 base_url=self._base_url,
-                timeout=Timeout(timeout=5.0),
+                timeout=Timeout(timeout=settings.ipfs.timeout),
                 follow_redirects=False,
                 transport=self._async_transport
             )

--- a/proto_sliding_window_cacher_service.py
+++ b/proto_sliding_window_cacher_service.py
@@ -3,7 +3,6 @@ import json
 import logging
 import sys
 from functools import wraps
-from tkinter import E
 from typing import Tuple
 from config import settings
 from async_ipfshttpclient.main import AsyncIPFSClient

--- a/proto_sliding_window_cacher_service.py
+++ b/proto_sliding_window_cacher_service.py
@@ -3,6 +3,8 @@ import json
 import logging
 import sys
 from functools import wraps
+from tkinter import E
+from typing import Tuple
 from config import settings
 from async_ipfshttpclient.main import AsyncIPFSClient
 from utils import redis_keys
@@ -59,7 +61,6 @@ async def find_tail(
         tail: int,
         project_id: str,
         time_period_ts: int,
-        registered_projects,
         redis_conn: aioredis.Redis,
         ipfs_read_client: AsyncIPFSClient
 ):
@@ -75,6 +76,14 @@ async def find_tail(
         reader_redis_conn=redis_conn,
         ipfs_read_client=ipfs_read_client
     )
+    if not head_block['data']['payload']:
+        sliding_cacher_logger.warning(
+            "Seeking tail against head block DAG CID %s height %s for time period %s"
+            "No payload found while fetching dag_block at height %s for projectId: %s. Skipping building of primary index",
+            head_block['data']['dag_cid'], head, time_period_ts,
+            current_height, project_id, exc_info=True
+        )
+        return None
     present_ts = head_block['data']['payload']['timestamp']
     while current_height < head:
         try:
@@ -84,7 +93,7 @@ async def find_tail(
                 reader_redis_conn=redis_conn,
                 ipfs_read_client=ipfs_read_client
             )
-            if dag_block and present_ts - dag_block['data']['payload']['timestamp'] <= time_period_ts:
+            if dag_block and dag_block['data']['payload'] and present_ts - dag_block['data']['payload']['timestamp'] <= time_period_ts:
                 sliding_cacher_logger.debug("Found tail after traversing %s blocks for projectId: %s:%d",
                                             abs(current_height - tail),
                                             project_id,
@@ -92,10 +101,12 @@ async def find_tail(
                 )
                 return current_height
         except Exception as err:
-            sliding_cacher_logger.error("Exception while fetching dag_block at height %s for projectId: %s. Error:%s",
-            current_height,
-            project_id,
-            err, exc_info=True)
+            sliding_cacher_logger.warning(
+                "Seeking tail against head block DAG CID %s height %s for time period %s"
+                "Exception while fetching dag_block at height %s for projectId: %s. Error:%s",
+                head_block['data']['dag_cid'], head, time_period_ts,
+                current_height, project_id, err, exc_info=True
+            )
         current_height += 1
 
     sliding_cacher_logger.error("Could not find tail for projectId:%s", project_id)
@@ -106,8 +117,7 @@ async def find_tail(
 async def build_primary_index(
         project_id: str,
         time_period: str,
-        height_map: dict,
-        registered_projects: list,
+        head_dag_block_height: int,
         semaphore: asyncio.BoundedSemaphore,
         writer_redis_conn: aioredis.Redis,
         ipfs_read_client: AsyncIPFSClient
@@ -120,7 +130,7 @@ async def build_primary_index(
     #  1. maybe don't store it? 2. or, might be useful state information?
     idx_head_key = redis_keys.get_sliding_window_cache_head_marker(project_id, time_period)
     idx_tail_key = redis_keys.get_sliding_window_cache_tail_marker(project_id, time_period)
-    head_marker = height_map.get('dag_block_height')
+    head_marker = head_dag_block_height
     tail_marker = None
 
     # if time_period is 0 then just set head and exit
@@ -135,7 +145,7 @@ async def build_primary_index(
         sliding_cacher_logger.info('Finding %s tail marker for the first time for project %s', time_period, project_id)
         #passing prev tail as 1 since we are looking for tail for the first time.
         tail_marker = await find_tail(
-            head_marker,1, project_id, time_period_ts, registered_projects, writer_redis_conn, ipfs_read_client
+            head_marker,1, project_id, time_period_ts, writer_redis_conn, ipfs_read_client
         )
         if not tail_marker:
             sliding_cacher_logger.error(
@@ -151,7 +161,7 @@ async def build_primary_index(
     else:
         tail_marker = int(markers[1])
         tail_ahead = await find_tail(
-            head_marker, tail_marker, project_id, time_period_ts, registered_projects, writer_redis_conn, ipfs_read_client
+            head_marker, tail_marker, project_id, time_period_ts, writer_redis_conn, ipfs_read_client
         )
         if not tail_ahead:
             sliding_cacher_logger.error(
@@ -169,6 +179,31 @@ async def build_primary_index(
                 'Set %s - %s index for %s data | Project ID: %s',
                 head_marker, tail_ahead, time_period, project_id
             )
+
+
+@acquire_bounded_semaphore
+async def get_epoch_end_per_project(
+    project_id: str,
+    semaphore: asyncio.BoundedSemaphore,
+    writer_redis_conn: aioredis.Redis,
+    ipfs_read_client: AsyncIPFSClient
+) -> Tuple[int, int]:
+    """
+    returns tuple of (head_dag_block_height_of_project, epoch_end_contained_in_head_dag_block)
+    """
+    project_height_key = redis_keys.get_block_height_key(project_id)
+    max_height = await writer_redis_conn.get(project_height_key)
+    if not max_height:
+        raise Exception("Can\'t fetch max block height against project ID: %s", project_id)
+    dag_block = await retrieval_utils.get_dag_block_by_height(
+        project_id=project_id,
+        block_height=int(max_height.decode('utf-8')),
+        reader_redis_conn=writer_redis_conn,
+        ipfs_read_client=ipfs_read_client
+    )
+    if not dag_block or not dag_block['data']['payload']:
+        return (int(max_height), 0)  # anomalous result to be filtered out by caller
+    return (int(max_height), dag_block['data']['payload']['chainHeightRange']['end'])
 
 
 @acquire_bounded_semaphore
@@ -238,64 +273,43 @@ async def build_primary_indexes(ipfs_read_client):
     registered_project_ids = [x.decode('utf-8') for x in registered_projects.keys()]
     registered_projects_ts = [json.loads(v)['series'] for v in registered_projects.values()]
     project_id_to_register_series = dict(zip(registered_project_ids, registered_projects_ts))
-    project_source_height_map = {}
 
     sliding_cacher_logger.debug("Fetching maximum height for all projectIds")
     tasks = list()
     semaphore = asyncio.BoundedSemaphore(20)
-    for project_id, ts_arr in project_id_to_register_series.items():
-        fn = get_max_height_pair_project(**{
-            'project_id': project_id,
-            'height_map': project_source_height_map,
-            'registered_projects': registered_projects,
-            'semaphore': semaphore,
-            'writer_redis_conn': writer_redis_conn,
-            'ipfs_read_client': ipfs_read_client
-        })
-        tasks.append(fn)
-    max_height_array = await asyncio.gather(*tasks, return_exceptions=True)
-    res_exceptions = list(map(lambda r: r, filter(lambda y: isinstance(y, Exception), max_height_array)))
-
-    if len(res_exceptions) == len(project_id_to_register_series):
-        sliding_cacher_logger.debug('block-height for all projects has not been intialized yet, sleeping till next cycle')
-        return
-    if len(res_exceptions) > 0:
-        sliding_cacher_logger.warning('Can\'t find projects max height for some projects, sleeping till next cycle | error_objs: %s', res_exceptions)
-        return
-
-    smallest_source_height = project_source_height_map[next(iter(project_source_height_map))]["source_height"]
-    for project_map_id, project_map in project_source_height_map.items():
-        smallest_source_height = int(project_map["source_height"]) if int(project_map["source_height"]) < int(smallest_source_height) else int(smallest_source_height)
-
-    sliding_cacher_logger.debug(f"Adjusting all projects height to match common minimum height: {smallest_source_height}")
-    try:
-        await adjust_projects_head_by_source_height(
-            project_source_height_map,
-            smallest_source_height,
-            registered_projects,
-            writer_redis_conn,
-            ipfs_read_client
+    for project_id in registered_project_ids:
+        tasks.append(
+            get_epoch_end_per_project(
+            project_id=project_id, 
+            semaphore=semaphore, 
+            writer_redis_conn=writer_redis_conn, 
+            ipfs_read_client=ipfs_read_client)
         )
-    except Exception as exc:
-        sliding_cacher_logger.error(f"can\'t adjust projects height for smallest source height | error_msg: {exc}")
-        return
 
+    epoch_ends_map = await asyncio.gather(*tasks, return_exceptions=True)
+    sliding_cacher_logger.debug("Fetched epoch end information for all projectIds: %s", epoch_ends_map)
+    try:
+        max_epoch_end = max(filter(lambda x: not(isinstance(x, Exception) or x[1] == 0), epoch_ends_map), key=lambda x: x[1])
+    except ValueError:
+        sliding_cacher_logger.error("Can\'t find max epoch end for all projects, sleeping till next cycle")
+        return
+    indexable_projects_to_dag_heights = {k: epoch_ends_map[idx][0] for idx, k in enumerate(registered_project_ids) if not(isinstance(epoch_ends_map[idx], Exception) or epoch_ends_map[idx][1] == 0)}
+    
     sliding_cacher_logger.debug(f"Start building indexes for all projects | project_count:{len(project_id_to_register_series)}")
     tasks = list()
-    for project_id, ts_arr in project_id_to_register_series.items():
-        for time_period in ts_arr:
-            height_map = project_source_height_map[project_id]
-            fn = build_primary_index(**{
-                'project_id': project_id,
-                'time_period': time_period,
-                'height_map': height_map,
-                'registered_projects': registered_projects,
-                'semaphore': semaphore,
-                'writer_redis_conn': writer_redis_conn,
-                'ipfs_read_client': ipfs_read_client
-            })
+    for project_id, head_dag_height in indexable_projects_to_dag_heights.items():
+        for time_period in project_id_to_register_series[project_id]:
+            fn = build_primary_index(
+                project_id=project_id,
+                time_period=time_period,
+                head_dag_block_height=head_dag_height,
+                semaphore=semaphore,
+                writer_redis_conn=writer_redis_conn,
+                ipfs_read_client=ipfs_read_client
+            )
             tasks.append(fn)
     await asyncio.gather(*tasks)
+    return max_epoch_end[1]
 
 
 async def periodic_retrieval():
@@ -317,12 +331,20 @@ async def periodic_retrieval():
     redis_conn: aioredis.Redis = aioredis_pool.writer_redis_pool
     while True:
         try:
-            await build_primary_indexes(ipfs_read_client=ipfs_read_client)
-            await asyncio.gather(
-                v2_pairs_data(async_httpx_client, ipfs_write_client, ipfs_read_client),
-                v2_pairs_daily_stats_snapshotter(async_httpx_client, ipfs_write_client, redis_conn),
-                asyncio.sleep(90)
-            )
+            common_epoch_end = await build_primary_indexes(ipfs_read_client=ipfs_read_client)
+            if common_epoch_end:
+                try:
+                    await asyncio.gather(
+                        v2_pairs_data(async_httpx_client, common_epoch_end, ipfs_write_client, ipfs_read_client),
+                        v2_pairs_daily_stats_snapshotter(async_httpx_client, ipfs_write_client, redis_conn),
+                        asyncio.sleep(90),
+                    )
+                except Exception as e:
+                    sliding_cacher_logger.error('Error in uniswap summary aggregation: ')
+                    sliding_cacher_logger.error(e, exc_info=True)
+                    await asyncio.sleep(90)
+            else:
+                await asyncio.sleep(90)
             sliding_cacher_logger.debug('Finished a cycle of indexing...')
         except Exception as err:
             sliding_cacher_logger.error("Exception occured in indexing and aggregation cycle %s",
@@ -351,3 +373,4 @@ if __name__ == "__main__":
         asyncio.get_event_loop().run_until_complete(f)
     except:
         asyncio.get_event_loop().stop()
+

--- a/utils/dag_utils.py
+++ b/utils/dag_utils.py
@@ -4,11 +4,9 @@ from utils import redis_keys
 from utils import helper_functions
 from data_models import PendingTransaction, DAGBlock, DAGFinalizerCallback, DAGBlockPayloadLinkedPath
 from tenacity import retry, wait_random_exponential, retry_if_exception_type, stop_after_attempt
-from typing import Tuple
+from typing import Optional, Tuple
 from httpx import AsyncClient
-import aiohttp
-import async_timeout
-import asyncio
+from httpx import _exceptions as httpx_exceptions
 import json
 import io
 import logging
@@ -95,22 +93,16 @@ async def save_event_data(event_data: DAGFinalizerCallback, pending_tx_set_entry
     )
 
 async def get_dag_block(dag_cid: str, project_id:str, ipfs_read_client: AsyncIPFSClient):
-    e_obj = None
     dag = read_text_file(settings.local_cache_path + "/" + project_id + "/"+ dag_cid + ".json", logger )
     if dag is None:
         logger.info("Failed to read dag-block with CID %s for project %s from local cache ",
         dag_cid,project_id)
         try:
-            async with async_timeout.timeout(settings.ipfs.timeout) as cm:
-                try:
-                    dag = await ipfs_read_client.dag.get(dag_cid)
-                    dag = dag.as_json()
-                except Exception as ex:
-                    e_obj = ex
-        except (asyncio.exceptions.CancelledError, asyncio.exceptions.TimeoutError) as err:
-            e_obj = err
-        if e_obj or cm.expired:
-            return {}
+            dag = await ipfs_read_client.dag.get(dag_cid)
+        except (httpx_exceptions.TransportError, httpx_exceptions.StreamError) as err:
+            return None
+        else:
+            dag = dag.as_json()
     else:
         dag = json.loads(dag)
     return dag
@@ -145,7 +137,7 @@ async def create_dag_block_update_project_state(tx_hash, request_id, project_id,
     if snapshot_cid.startswith('null'):
         logger.info("Creating an DAG block with null payload for project %s !!!!",
                     project_id)
-        snapshot_cid=""
+        snapshot_cid=None
     _dag_cid, dag_block = await create_dag_block(
         tx_hash=tx_hash,
         project_id=project_id,
@@ -236,7 +228,7 @@ async def create_dag_block(
         tx_hash: str,
         project_id: str,
         tentative_block_height: int,
-        payload_cid: str,
+        payload_cid: Optional[str],
         timestamp: int,
         reader_redis_conn: aioredis.Redis,
         writer_redis_conn: aioredis.Redis,

--- a/v2_pairs_daily_stats_snapshotter.py
+++ b/v2_pairs_daily_stats_snapshotter.py
@@ -148,13 +148,14 @@ async def v2_pairs_daily_stats_snapshotter(
             # fetch current and 24h old snapshot payload
             dag_block_latest, dag_block_24h = await asyncio.gather(
                 retrieve_payload_data(
-                    latest_pair_summary_timestamp_payload_cid,
-                    redis_keys.get_uniswap_pairs_summary_snapshot_project_id(settings.pooler_namespace),
-                    ipfs_read_client),
+                    payload_cid=latest_pair_summary_timestamp_payload_cid,
+                    project_id=redis_keys.get_uniswap_pairs_summary_snapshot_project_id(settings.pooler_namespace),
+                    ipfs_read_client=ipfs_read_client
+                ),
                 retrieve_payload_data(
-                    pair_snapshot_payload_cid_24h,
-                    redis_keys.get_uniswap_pairs_summary_snapshot_project_id(settings.pooler_namespace),
-                    ipfs_read_client),
+                    payload_cid=pair_snapshot_payload_cid_24h,
+                    project_id=redis_keys.get_uniswap_pairs_summary_snapshot_project_id(settings.pooler_namespace),
+                    ipfs_read_client=ipfs_read_client),
                 return_exceptions=True
             )
             # handle case of null payload in dag_block

--- a/v2_pairs_daily_stats_snapshotter.py
+++ b/v2_pairs_daily_stats_snapshotter.py
@@ -54,17 +54,18 @@ def v2_pair_data_unpack(prop):
 
 def link_contract_objs_of_v2_pairs_snapshot(recent_v2_pairs_snapshot, old_v2_pairs_snapshot):
     linked_contract_snapshot = {}
-    for new_contract_obj in recent_v2_pairs_snapshot:
-        linked_contract_snapshot[new_contract_obj["contractAddress"]] = {
-            "recent": new_contract_obj
-        }
+    if recent_v2_pairs_snapshot:
+        for new_contract_obj in recent_v2_pairs_snapshot:
+            linked_contract_snapshot[new_contract_obj["contractAddress"]] = {
+                "recent": new_contract_obj
+            }
 
-        for old_contract_obj in old_v2_pairs_snapshot:
-            if new_contract_obj["contractAddress"] == old_contract_obj["contractAddress"]:
-                linked_contract_snapshot[new_contract_obj["contractAddress"]]["old"] = old_contract_obj
+            if old_v2_pairs_snapshot:
+                for old_contract_obj in old_v2_pairs_snapshot:
+                    if new_contract_obj["contractAddress"] == old_contract_obj["contractAddress"]:
+                        linked_contract_snapshot[new_contract_obj["contractAddress"]]["old"] = old_contract_obj
 
-    return linked_contract_snapshot
-
+        return linked_contract_snapshot
 
 async def v2_pairs_daily_stats_snapshotter(
         async_httpx_client: AsyncClient,


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #5 

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
<!-- Describe the code you are going to change and its behaviour -->
The present architecture of the indexer and aggregator services that generate important datapoints for the Uniswap v2 use case does not deal well with broken chains and skipped snapshots that can arise because of

* network errors
* cache errors
* RPC timeouts or rate limits

...among many other factors that can go wrong.

Its attempt to find a common end epoch across 100+ projects to just get started on building aggregates along with a lot of convoluted logic on trying to sync up other higher order aggregates with the same causes the entire process to come to a halt in case of above issues creating gaps or duplicate entries in snapshot chains. The end result is that even though snapshots continue to proceed fine, there are no usable data points generated or updated.


### New expected behaviour
<!-- Describe the new code and its expected behaviour -->
The indexing and aggregation systems try to continue progressing ahead as long as majority of the snapshotted projects' snapshot chains progress fine. A couple of projects with broken chains should not cause an entire cessation in data point generation and updation.

These aggregated data points are themselves registered as 'projects' with audit protocol and can be tracked at a summary level for noting missed snapshots and skipped epochs in the individual pair contracts's projects that make up the summary.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


#### Changed
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
* Indexes (24h, 7 days), aggregates (trade volume, `token0` and `token1` reserves, fees accumulated etc) of a pair contract are referenced by the latest block height contained in the epoch of the latest DAG block in the chain of snapshots. The latest block height of the epoch corresponds to the data source chain (eg, Ethereum mainnet for instances tracking Uniswap v2 data)

<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


#### Removed
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
* For super aggregates (for eg, generating summary of trade volume across all Uniswap v2 pair contracts being tracked by a snapshotting network), it is not attempted to arrive at a common minimum epoch end across the chain of snapshots maintained for each individual pair contract.
* [Relevant section in whitepaper](https://www.notion.so/powerloom/PowerLoom-Protocol-Overview-c3bf9dd9323541118d46a4d8684565d1?pvs=4#77c4c26126ec4c22bd22d118910ce30d). This will be updated once the PR is merged.

## Deployment Instructions
<!-- Any specific deployment instructions to deploy your code -->
Restart `ap-proto-indexer` service from `pm2.config.js`