### PR TITLE
fix: ipfs connection check and retry http fix

### DIFF
--- a/go/goutils/ipfsutils/ipfs_utils.go
+++ b/go/goutils/ipfsutils/ipfs_utils.go
@@ -60,6 +60,12 @@ func InitClient(url string, rateLimiter *settings.RateLimiter, timeoutSecs int) 
 		log.Fatalln("Failed to inject dependencies", err)
 	}
 
+	// check if ipfs connection is successful
+	_, _, err := client.ipfsClient.Version()
+	if err != nil {
+		log.WithError(err).Fatal("failed to connect to IPFS daemon")
+	}
+
 	return client
 }
 

--- a/go/goutils/reporting/reporting.go
+++ b/go/goutils/reporting/reporting.go
@@ -137,6 +137,10 @@ func (i *IssueReporter) ReportOnSlack(issue []byte) {
 }
 
 func (i *IssueReporter) ReportToOffchainConsensus(issue []byte) {
+	if i.settingsObj.Reporting.OffchainConsensusIssueEndpoint == "" {
+		return
+	}
+
 	req, err := retryablehttp.NewRequest(http.MethodPost, i.settingsObj.Reporting.OffchainConsensusIssueEndpoint, bytes.NewBuffer(issue))
 	if err != nil {
 		log.WithError(err).Error("failed to create request to slack webhook url")

--- a/go/goutils/settings/settings.go
+++ b/go/goutils/settings/settings.go
@@ -47,7 +47,7 @@ type (
 	}
 
 	IpfsConfig struct {
-		URL             string       `json:"url"`
+		URL             string       `json:"url" validate:"required"`
 		ReaderURL       string       `json:"reader_url"`
 		IPFSRateLimiter *RateLimiter `json:"write_rate_limit,omitempty"`
 		Timeout         int          `json:"timeout"`

--- a/go/goutils/w3s/w3s.go
+++ b/go/goutils/w3s/w3s.go
@@ -68,6 +68,10 @@ func InitW3S() *W3S {
 func (w *W3S) UploadToW3s(msg interface{}) (string, error) {
 	log.Debug("uploading payload commit message to web3 storage")
 
+	if w.settingsObj.Web3Storage.URL == "" {
+		return "", nil
+	}
+
 	reqURL := w.settingsObj.Web3Storage.URL + w.settingsObj.Web3Storage.UploadURLSuffix
 
 	payloadCommit, err := json.Marshal(msg)

--- a/go/payload-commit/service/service.go
+++ b/go/payload-commit/service/service.go
@@ -452,7 +452,7 @@ func (s *PayloadCommitService) uploadToIPFSandW3s(msg *datamodel.PayloadCommitMe
 		return fmt.Errorf("failed to upload to ipfs and web3 storage")
 	}
 
-	if ipfsUploadErr != nil && w3sUploadErr == nil {
+	if ipfsUploadErr != nil && w3sUploadErr == nil && snapshotCid != "" {
 		msg.SnapshotCID = snapshotCid
 
 		return nil


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

IPFS connection url is required in config and other fixes

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.

### Current behaviour
If IPFS connection url is not present/ invalid in config initialising IPFS client does not throw any error.

### New expected behaviour
- If IPFS connection url is not present in config payload-commit and pruning service will fail with url required error.
- If IPFS connection url is invalid in config payload-commit and pruning service will fail with error in initialising IPFS client

### Change logs
- Added check for IPFS url to be present while parsing `settings.json`
- Checking IPFS client connection is successful

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->
