### PR TITLE
feat: adding support for 3rd party IPFS provider and Redis connection changes

### DIFF
--- a/go/caching/redis.go
+++ b/go/caching/redis.go
@@ -17,21 +17,16 @@ import (
 )
 
 type RedisCache struct {
-	redisClient *redis.Client
+	readClient  *redis.Client
+	writeClient *redis.Client
 }
 
 var _ DbCache = (*RedisCache)(nil)
 
-func NewRedisCache() *RedisCache {
-	client, err := gi.Invoke[*redis.Client]()
-	if err != nil {
-		log.Fatal("Failed to invoke redis client", err)
-	}
+func NewRedisCache(readClient, writeClient *redis.Client) *RedisCache {
+	cache := &RedisCache{readClient: readClient, writeClient: writeClient}
 
-	cache := &RedisCache{redisClient: client}
-
-	err = gi.Inject(cache)
-	if err != nil {
+	if err := gi.Inject(cache); err != nil {
 		log.Fatal("Failed to inject redis cache", err)
 	}
 
@@ -48,7 +43,7 @@ func (r *RedisCache) GetSnapshotAtEpochID(ctx context.Context, projectID string,
 		WithField("key", key).
 		Debug("getting snapshotCid from redis at given epochId from the given projectId")
 
-	res, err := r.redisClient.ZRangeByScoreWithScores(ctx, key, &redis.ZRangeBy{
+	res, err := r.readClient.ZRangeByScoreWithScores(ctx, key, &redis.ZRangeBy{
 		Min: height,
 		Max: height,
 	}).Result()
@@ -89,7 +84,7 @@ func (r *RedisCache) GetSnapshotAtEpochID(ctx context.Context, projectID string,
 func (r *RedisCache) GetStoredProjects(ctx context.Context) ([]string, error) {
 	key := redisutils.REDIS_KEY_STORED_PROJECTS
 
-	val, err := r.redisClient.SMembers(ctx, key).Result()
+	val, err := r.readClient.SMembers(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
 			log.Errorf("error getting stored projects, key %s not found", key)
@@ -104,7 +99,7 @@ func (r *RedisCache) GetStoredProjects(ctx context.Context) ([]string, error) {
 }
 
 func (r *RedisCache) CheckIfProjectExists(ctx context.Context, projectID string) (bool, error) {
-	res, err := r.redisClient.Keys(ctx, fmt.Sprintf("projectID:%s:*", projectID)).Result()
+	res, err := r.readClient.Keys(ctx, fmt.Sprintf("projectID:%s:*", projectID)).Result()
 	if err != nil {
 		log.WithError(err).Error("failed to check if project exists")
 
@@ -120,7 +115,7 @@ func (r *RedisCache) CheckIfProjectExists(ctx context.Context, projectID string)
 
 // StoreProjects stores the given projects in the redis cache.
 func (r *RedisCache) StoreProjects(background context.Context, projects []string) error {
-	_, err := r.redisClient.SAdd(background, redisutils.REDIS_KEY_STORED_PROJECTS, projects).Result()
+	_, err := r.writeClient.SAdd(background, redisutils.REDIS_KEY_STORED_PROJECTS, projects).Result()
 
 	if err != nil {
 		log.WithError(err).Error("failed to store projects")
@@ -144,7 +139,7 @@ func (r *RedisCache) AddUnfinalizedSnapshotCID(ctx context.Context, msg *datamod
 
 	data, _ := json.Marshal(p)
 
-	err := r.redisClient.ZAdd(ctx, key, &redis.Z{
+	err := r.writeClient.ZAdd(ctx, key, &redis.Z{
 		Score:  float64(msg.EpochID),
 		Member: string(data),
 	}).Err()
@@ -155,7 +150,7 @@ func (r *RedisCache) AddUnfinalizedSnapshotCID(ctx context.Context, msg *datamod
 	}
 
 	// get all the members
-	res, err := r.redisClient.ZRangeByScoreWithScores(ctx, key, &redis.ZRangeBy{
+	res, err := r.writeClient.ZRangeByScoreWithScores(ctx, key, &redis.ZRangeBy{
 		Min: "-inf",
 		Max: "+inf",
 	}).Result()
@@ -183,7 +178,7 @@ func (r *RedisCache) AddUnfinalizedSnapshotCID(ctx context.Context, msg *datamod
 		}
 
 		if float64(m.Expiration) < float64(time.Now().Unix()) {
-			err = r.redisClient.ZRem(ctx, key, member.Member).Err()
+			err = r.writeClient.ZRem(ctx, key, member.Member).Err()
 			if err != nil {
 				log.WithError(err).Error("failed to remove expired snapshot cid from zset")
 			}
@@ -210,7 +205,7 @@ func (r *RedisCache) AddSnapshotterStatusReport(ctx context.Context, epochId int
 			return err
 		}
 
-		err = r.redisClient.HSet(ctx, key, strconv.Itoa(epochId), string(reportJson)).Err()
+		err = r.writeClient.HSet(ctx, key, strconv.Itoa(epochId), string(reportJson)).Err()
 		if err != nil {
 			log.WithError(err).Error("failed to add snapshotter status report in redis")
 
@@ -227,7 +222,7 @@ func (r *RedisCache) AddSnapshotterStatusReport(ctx context.Context, epochId int
 		key = fmt.Sprintf(redisutils.REDIS_KEY_TOTAL_SUCCESSFUL_SNAPSHOT_COUNT, projectId)
 	}
 
-	err := r.redisClient.Incr(ctx, key).Err()
+	err := r.writeClient.Incr(ctx, key).Err()
 	if err != nil {
 		log.WithError(err).Error("failed to increment total missed snapshot count")
 	}

--- a/go/goutils/redisutils/redis_client.go
+++ b/go/goutils/redisutils/redis_client.go
@@ -4,39 +4,51 @@ import (
 	"context"
 	"net"
 	"strconv"
-	"time"
-
-	"github.com/swagftw/gi"
 
 	"github.com/go-redis/redis/v8"
 	log "github.com/sirupsen/logrus"
 )
 
-func InitRedisClient(redisHost string, port int, redisDb int, poolSize int, password string, timeout time.Duration) *redis.Client {
+func InitReaderRedisClient(redisHost string, port int, redisDb int, poolSize int, password string) *redis.Client {
 	redisURL := net.JoinHostPort(redisHost, strconv.Itoa(port))
 
-	log.Info("connecting to redis at:", redisURL)
+	log.Info("connecting to reader redis at:", redisURL)
 
 	redisClient := redis.NewClient(&redis.Options{
-		Addr:        redisURL,
-		Password:    password,
-		DB:          redisDb,
-		PoolSize:    poolSize,
-		ReadTimeout: timeout,
+		Addr:     redisURL,
+		Password: password,
+		DB:       redisDb,
+		PoolSize: poolSize,
 	})
 
 	pong, err := redisClient.Ping(context.Background()).Result()
 	if err != nil {
-		log.WithField("addr", redisURL).Fatal("Unable to connect to redis")
+		log.WithField("addr", redisURL).Fatal("Unable to connect to reader redis")
 	}
 
-	log.Info("Connected successfully to Redis and received ", pong, " back")
+	log.Info("Connected successfully to reader Redis and received ", pong, " back")
 
-	// exit if injection fails
-	err = gi.Inject(redisClient)
+	return redisClient
+}
+
+func InitWriterRedisClient(redisHost string, port int, redisDb int, poolSize int, password string) *redis.Client {
+	redisURL := net.JoinHostPort(redisHost, strconv.Itoa(port))
+
+	log.Info("connecting to writer redis at:", redisURL)
+
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:     redisURL,
+		Password: password,
+		DB:       redisDb,
+		PoolSize: poolSize,
+	})
+
+	pong, err := redisClient.Ping(context.Background()).Result()
 	if err != nil {
-		log.Fatalln("Failed to inject redis client", err)
+		log.WithField("addr", redisURL).Fatal("Unable to connect to writer redis")
 	}
+
+	log.Info("Connected successfully to writer Redis and received ", pong, " back")
 
 	return redisClient
 }

--- a/go/goutils/reporting/reporting.go
+++ b/go/goutils/reporting/reporting.go
@@ -35,7 +35,7 @@ type IssueReporter struct {
 
 func InitIssueReporter(settingsObj *settings.SettingsObj) *IssueReporter {
 	client := &IssueReporter{
-		httpClient:       httpclient.GetDefaultHTTPClient(),
+		httpClient:       httpclient.GetDefaultHTTPClient(settingsObj.HttpClient.ConnectionTimeout),
 		slackRateLimiter: rate.NewLimiter(1, 1),
 		settingsObj:      settingsObj,
 	}

--- a/go/goutils/settings/settings.go
+++ b/go/goutils/settings/settings.go
@@ -191,4 +191,14 @@ func SetDefaults(settingsObj *SettingsObj) {
 	if privKey != "" {
 		settingsObj.Signer.PrivateKey = privKey
 	}
+
+	ipfsProjectApiKey := os.Getenv("IPFS_PROJECT_API_KEY")
+	if ipfsProjectApiKey != "" {
+		settingsObj.IpfsConfig.ProjectApiKey = ipfsProjectApiKey
+	}
+
+	ipfsProjectApiSecret := os.Getenv("IPFS_PROJECT_API_SECRET")
+	if ipfsProjectApiSecret != "" {
+		settingsObj.IpfsConfig.ProjectApiSecret = ipfsProjectApiSecret
+	}
 }

--- a/go/goutils/settings/settings.go
+++ b/go/goutils/settings/settings.go
@@ -47,12 +47,14 @@ type (
 	}
 
 	IpfsConfig struct {
-		URL             string       `json:"url" validate:"required"`
-		ReaderURL       string       `json:"reader_url"`
-		IPFSRateLimiter *RateLimiter `json:"write_rate_limit,omitempty"`
-		Timeout         int          `json:"timeout"`
-		MaxIdleConns    int          `json:"max_idle_conns"`
-		IdleConnTimeout int          `json:"idle_conn_timeout"`
+		URL              string       `json:"url" validate:"required"`
+		ReaderURL        string       `json:"reader_url"`
+		IPFSRateLimiter  *RateLimiter `json:"write_rate_limit,omitempty"`
+		Timeout          int          `json:"timeout"`
+		MaxIdleConns     int          `json:"max_idle_conns"`
+		IdleConnTimeout  int          `json:"idle_conn_timeout"`
+		ProjectApiKey    string       `json:"project_api_key"`
+		ProjectApiSecret string       `json:"project_api_secret"`
 	}
 
 	Redis struct {
@@ -96,6 +98,7 @@ type (
 		MaxConnsPerHost     int `json:"max_conns_per_host"`
 		MaxIdleConnsPerHost int `json:"max_idle_conns_per_host"`
 		IdleConnTimeout     int `json:"idle_conn_timeout"`
+		ConnectionTimeout   int `json:"connection_timeout"`
 	}
 
 	Reporting struct {

--- a/go/goutils/settings/settings.go
+++ b/go/goutils/settings/settings.go
@@ -47,14 +47,20 @@ type (
 	}
 
 	IpfsConfig struct {
-		URL              string       `json:"url" validate:"required"`
-		ReaderURL        string       `json:"reader_url"`
-		IPFSRateLimiter  *RateLimiter `json:"write_rate_limit,omitempty"`
-		Timeout          int          `json:"timeout"`
-		MaxIdleConns     int          `json:"max_idle_conns"`
-		IdleConnTimeout  int          `json:"idle_conn_timeout"`
-		ProjectApiKey    string       `json:"project_api_key"`
-		ProjectApiSecret string       `json:"project_api_secret"`
+		URL              string          `json:"url" validate:"required"`
+		ReaderURL        string          `json:"reader_url"`
+		WriteRateLimiter *RateLimiter    `json:"write_rate_limit,omitempty"`
+		ReadRateLimiter  *RateLimiter    `json:"read_rate_limit,omitempty"`
+		Timeout          int             `json:"timeout"`
+		MaxIdleConns     int             `json:"max_idle_conns"`
+		IdleConnTimeout  int             `json:"idle_conn_timeout"`
+		ReaderAuthConfig *IPFSAuthConfig `json:"reader_auth_config"`
+		WriterAuthConfig *IPFSAuthConfig `json:"writer_auth_config"`
+	}
+
+	IPFSAuthConfig struct {
+		ProjectApiKey    string `json:"project_api_key"`
+		ProjectApiSecret string `json:"project_api_secret"`
 	}
 
 	Redis struct {
@@ -192,13 +198,23 @@ func SetDefaults(settingsObj *SettingsObj) {
 		settingsObj.Signer.PrivateKey = privKey
 	}
 
-	ipfsProjectApiKey := os.Getenv("IPFS_PROJECT_API_KEY")
-	if ipfsProjectApiKey != "" {
-		settingsObj.IpfsConfig.ProjectApiKey = ipfsProjectApiKey
+	ipfsReaderProjectApiKey := os.Getenv("IPFS_READER_PROJECT_API_KEY")
+	if ipfsReaderProjectApiKey != "" {
+		settingsObj.IpfsConfig.ReaderAuthConfig.ProjectApiKey = ipfsReaderProjectApiKey
 	}
 
-	ipfsProjectApiSecret := os.Getenv("IPFS_PROJECT_API_SECRET")
-	if ipfsProjectApiSecret != "" {
-		settingsObj.IpfsConfig.ProjectApiSecret = ipfsProjectApiSecret
+	ipfsReaderProjectApiSecret := os.Getenv("IPFS_READER_PROJECT_API_SECRET")
+	if ipfsReaderProjectApiSecret != "" {
+		settingsObj.IpfsConfig.ReaderAuthConfig.ProjectApiSecret = ipfsReaderProjectApiSecret
+	}
+
+	ipfsWriterProjectApiKey := os.Getenv("IPFS_WRITER_PROJECT_API_KEY")
+	if ipfsWriterProjectApiKey != "" {
+		settingsObj.IpfsConfig.WriterAuthConfig.ProjectApiKey = ipfsWriterProjectApiKey
+	}
+
+	ipfsWriterProjectApiSecret := os.Getenv("IPFS_WRITER_PROJECT_API_SECRET")
+	if ipfsWriterProjectApiSecret != "" {
+		settingsObj.IpfsConfig.WriterAuthConfig.ProjectApiSecret = ipfsWriterProjectApiSecret
 	}
 }

--- a/go/goutils/settings/settings.go
+++ b/go/goutils/settings/settings.go
@@ -76,6 +76,7 @@ type (
 		Port     int    `json:"port"`
 		Db       int    `json:"db"`
 		Password string `json:"password"`
+		PoolSize int    `json:"pool_size"`
 	}
 
 	Web3Storage struct {

--- a/go/goutils/smartcontract/smart_contract.go
+++ b/go/goutils/smartcontract/smart_contract.go
@@ -23,7 +23,7 @@ func InitContractAPI() *contractApi.ContractApi {
 		log.Fatal("failed to invoke settings object")
 	}
 
-	httpClient := httpclient.GetDefaultHTTPClient()
+	httpClient := httpclient.GetDefaultHTTPClient(settingsObj.HttpClient.ConnectionTimeout)
 
 	rpClient, err := rpc.DialOptions(context.Background(), settingsObj.AnchorChainRPCURL, rpc.WithHTTPClient(httpClient.HTTPClient))
 	if err != nil {

--- a/go/goutils/w3s/w3s.go
+++ b/go/goutils/w3s/w3s.go
@@ -54,7 +54,7 @@ func InitW3S() *W3S {
 	w := &W3S{
 		limiter:           rateLimiter,
 		settingsObj:       settingsObj,
-		defaultHTTPClient: httpclient.GetDefaultHTTPClient(),
+		defaultHTTPClient: httpclient.GetDefaultHTTPClient(settingsObj.Web3Storage.Timeout),
 	}
 
 	err = gi.Inject(w)

--- a/go/payload-commit/main.go
+++ b/go/payload-commit/main.go
@@ -22,11 +22,7 @@ func main() {
 
 	settingsObj := settings.ParseSettings()
 
-	ipfsutils.InitClient(
-		settingsObj.IpfsConfig.URL,
-		settingsObj.IpfsConfig.IPFSRateLimiter,
-		settingsObj.IpfsConfig.Timeout,
-	)
+	ipfsutils.InitClient(settingsObj)
 
 	redisClient := redisutils.InitRedisClient(
 		settingsObj.Redis.Host,

--- a/go/payload-commit/service/service.go
+++ b/go/payload-commit/service/service.go
@@ -107,7 +107,7 @@ func InitPayloadCommitService(reporter *reporting.IssueReporter) *PayloadCommitS
 		txManager:     transactions.NewNonceManager(),
 		privKey:       privKey,
 		issueReporter: reporter,
-		httpClient:    httpclient.GetDefaultHTTPClient(),
+		httpClient:    httpclient.GetDefaultHTTPClient(settingsObj.HttpClient.ConnectionTimeout),
 	}
 
 	_ = pcService.initLocalCachedData()

--- a/go/payload-commit/service/service.go
+++ b/go/payload-commit/service/service.go
@@ -311,7 +311,7 @@ func (s *PayloadCommitService) HandleFinalizedPayloadCommitTask(msg *datamodel.P
 		// if stored snapshot cid does not match with finalized snapshot cid, fetch snapshot from ipfs and store in local disk.
 		log.Debug("cached snapshot cid does not match with finalized snapshot cid, fetching snapshot commit message from ipfs")
 
-		s.issueReporter.Report(
+		go s.issueReporter.Report(
 			reporting.SubmittedIncorrectSnapshotIssue,
 			msg.Message.ProjectID,
 			strconv.Itoa(msg.Message.EpochID),

--- a/go/pruning/main.go
+++ b/go/pruning/main.go
@@ -15,11 +15,7 @@ func main() {
 
 	settingsObj := settings.ParseSettings()
 
-	ipfsClient := ipfsutils.InitClient(
-		settingsObj.IpfsConfig.URL,
-		settingsObj.IpfsConfig.IPFSRateLimiter,
-		settingsObj.IpfsConfig.Timeout,
-	)
+	ipfsClient := ipfsutils.InitClient(settingsObj)
 
 	cronRunner := cron.New(cron.WithChain(
 		cron.Recover(cron.DefaultLogger),

--- a/go/pruning/simulation/simulation.go
+++ b/go/pruning/simulation/simulation.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	ipfsClient := ipfsutils.InitClient(settingsObj.IpfsConfig.URL, settingsObj.IpfsConfig.IPFSRateLimiter, settingsObj.IpfsConfig.Timeout)
+	ipfsClient := ipfsutils.InitClient(settingsObj)
 
 	state := new(State)
 

--- a/settings.example.json
+++ b/settings.example.json
@@ -31,12 +31,22 @@
   "ipfs": {
     "url": "/dns/ipfs/tcp/5001",
     "reader_url": "/dns/ipfs/tcp/5001",
+    "reader_auth_config": {
+      "project_api_key": "ipfs-project-id",
+      "project_api_secret": "ipfs-project-secret"
+    },
+    "writer_auth_config": {
+      "project_api_key": "ipfs-project-id",
+      "project_api_secret": "ipfs-project-secret"
+    },
     "write_rate_limit": {
       "req_per_sec": 130,
       "burst": 1
     },
-    "project_api_key": "ipfs-project-id",
-    "project_api_secret": "ipfs-project-secret",
+    "read_rate_limit": {
+      "req_per_sec": 1200,
+      "burst": 1
+    },
     "timeout": 120,
     "max_idle_conns": 5,
     "idle_conn_timeout": 0

--- a/settings.example.json
+++ b/settings.example.json
@@ -55,13 +55,15 @@
     "host": "redis",
     "port": 6379,
     "db": 0,
-    "password": null
+    "password": null,
+    "pool_size": 10
   },
   "redis_reader": {
     "host": "redis",
     "port": 6379,
     "db": 0,
-    "password": null
+    "password": null,
+    "pool_size": 10
   },
   "web3_storage": {
     "url": "https://api.web3.storage",

--- a/settings.example.json
+++ b/settings.example.json
@@ -9,7 +9,8 @@
     "max_idle_conns": 5,
     "max_conns_per_host": 5,
     "max_idle_conns_per_host": 5,
-    "idle_conn_timeout": 60
+    "idle_conn_timeout": 60,
+    "connection_timeout": 60
   },
   "rabbitmq": {
     "user": "guest",
@@ -34,6 +35,8 @@
       "req_per_sec": 130,
       "burst": 1
     },
+    "project_api_key": "ipfs-project-id",
+    "project_api_secret": "ipfs-project-secret",
     "timeout": 120,
     "max_idle_conns": 5,
     "idle_conn_timeout": 0
@@ -75,7 +78,8 @@
   },
   "relayer": {
     "host": "0.0.0.0:8080",
-    "endpoint": "/endpoint"
+    "endpoint": "/endpoint",
+    "timeout": 60
   },
   "pruning": {
     "ipfs_pinning_max_age_in_days": 7,


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Adding support for 3rd party IPFS, like [Infura IPFS provider](https://www.infura.io/product/ipfs)
### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.

### Current behaviour
- Currently, 3rd party IPFS API is not supported because of missing configuration and http authentication in place.
- Service is using single Redis client connection for both read and write ops

### New expected behaviour
New configuration and http authentication secrets related changes have been added which optionally takes authentication config to connect with remote API

```go
type IpfsConfig struct {
    URL              string          `json:"url" validate:"required"`
    ReaderURL        string          `json:"reader_url"`
    WriteRateLimiter *RateLimiter    `json:"write_rate_limit,omitempty"`
    ReadRateLimiter  *RateLimiter    `json:"read_rate_limit,omitempty"`
    Timeout          int             `json:"timeout"`
    MaxIdleConns     int             `json:"max_idle_conns"`
    IdleConnTimeout  int             `json:"idle_conn_timeout"`
    ReaderAuthConfig *IPFSAuthConfig `json:"reader_auth_config"`
    WriterAuthConfig *IPFSAuthConfig `json:"writer_auth_config"`
}

type IPFSAuthConfig struct {
    ProjectApiKey    string `json:"project_api_key"`
    ProjectApiSecret string `json:"project_api_secret"`
}
```

settings.example.json has been updated
```json
"reader_auth_config": {
  "project_api_key": "ipfs-project-id",
  "project_api_secret": "ipfs-project-secret"
},
"writer_auth_config": {
  "project_api_key": "ipfs-project-id",
  "project_api_secret": "ipfs-project-secret"
},
```
### Change logs
- New configuration is used to create http transport with basic auth
https://github.com/PowerLoom/audit-protocol/blob/674fbed6a7f8f7ca2d9c73cb72b1d844c0c49b95/go/goutils/httpclient/http_client.go#L52-L123

- Separate Redis client connections for read and write operations

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
Add valid authentication config as showed above if required for provided service URL. Complete `settings.example.json` [changes](https://github.com/PowerLoom/audit-protocol/pull/27/files#diff-8c1f82330b66269539d9caa514a987fa51eb9fa37ffcea37bcbc99a8535c54c7) 
Multiaddress formatted url support is still there.
In case of 3rd party provider (Infura in this case) multiaddr url will look like `/dns/ipfs.infura.io/tcp/5001/https` 