### PR TITLE
refactor: renaming namespace to UNISWAPV2

### DIFF
--- a/go/payload-commit/service/service.go
+++ b/go/payload-commit/service/service.go
@@ -369,7 +369,7 @@ func (s *PayloadCommitService) HandleFinalizedPayloadCommitTask(msg *datamodel.P
 			log.WithError(err).WithField("cid", unfinalizedSnapshot.SnapshotCID).Error("failed to unpin snapshot cid from ipfs")
 		}
 	} else {
-		err = s.redisCache.StoreLastFinalizedEpoch(context.Background(), msg.Message.ProjectID, prevEpochId)
+		err = s.redisCache.StoreLastFinalizedEpoch(context.Background(), msg.Message.ProjectID, msg.Message.EpochID)
 		if err != nil {
 			log.WithError(err).Error("failed to store last finalized epoch")
 		}

--- a/snapshotter_autofill.sh
+++ b/snapshotter_autofill.sh
@@ -47,7 +47,7 @@ fi
 
 cp settings.example.json settings.json
 
-export namespace=UNISWAPV2-ph15-prod
+export namespace=UNISWAPV2
 export prost_rpc_url="${PROST_RPC_URL:-https://rpc-prost1b.powerloom.io}"
 
 export ipfs_url="${IPFS_URL:-/dns/ipfs/tcp/5001}"


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Renaming `UNISWAPV2-ph15-prod` to `UNISWAPV2`

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.

### Current behaviour
Currently, `namespace` is being used in Audit Protocol for unique naming of rabbitmq exchanges and queues  

### New expected behaviour
Renaming `namespace` wont have any direct effect on behaviour of Audit Protocol in general, just better and clear naming.

Check [Pooler PR](https://github.com/PowerLoom/pooler/pull/27) for more information

## Deployment Instructions
NA
