### PR TITLE
Allowing both multiaddr and http URLs for ipfs client

### DIFF
--- a/go/goutils/ipfsutils/ipfs_utils.go
+++ b/go/goutils/ipfsutils/ipfs_utils.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
+	"net/url"
+	"strings"
 	"time"
 
 	shell "github.com/ipfs/go-ipfs-api"
@@ -30,16 +33,16 @@ type IpfsClient struct {
 func InitClient(settingsObj *settings.SettingsObj) *IpfsClient {
 	writeUrl := settingsObj.IpfsConfig.URL
 
-	writeUrl, err := ParseMultiAddrURL(writeUrl)
+	writeUrl, err := ParseURL(writeUrl)
 	if err != nil {
-		log.WithError(err).Fatal("failed to parse IPFS write multiaddr URL: ", writeUrl)
+		log.WithError(err).Fatal("failed to parse IPFS write URL: ", writeUrl)
 	}
 
 	readUrl := settingsObj.IpfsConfig.ReaderURL
 
-	readUrl, err = ParseMultiAddrURL(readUrl)
+	readUrl, err = ParseURL(readUrl)
 	if err != nil {
-		log.WithError(err).Fatal("failed to parse IPFS read multiaddr URL: ", readUrl)
+		log.WithError(err).Fatal("failed to parse IPFS read URL: ", readUrl)
 	}
 
 	ipfsReadHTTPClient := httpclient.GetIPFSReadHTTPClient(settingsObj)
@@ -127,28 +130,28 @@ func (e *UnsupportedMultiaddrError) Error() string {
 	return fmt.Sprintf("unsupported multiaddr url pattern: %s", e.URL)
 }
 
-// ParseMultiAddrURL tries to parse a multiaddr URL, if the url is not multiaddr it returns url as it is
-func ParseMultiAddrURL(url string) (string, error) {
+// ParseURL tries to parse a multiaddr URL, if the url is not multiaddr it tries to parse http url.
+func ParseURL(ipfsUrl string) (string, error) {
 	parts := make([]string, 0) // [host,port,scheme]
 
-	if multiaddr, err := ma.NewMultiaddr(url); err == nil {
+	if multiaddr, err := ma.NewMultiaddr(ipfsUrl); err == nil {
 		addrSplits := ma.Split(multiaddr)
 
 		// host and port are required
 		if len(addrSplits) < 2 {
-			return "", &UnsupportedMultiaddrError{URL: url}
+			return "", &UnsupportedMultiaddrError{URL: ipfsUrl}
 		}
 
 		for index, addr := range addrSplits {
 			component, _ := ma.SplitFirst(addr)
 			if index == 1 && component.Protocol().Code != ma.P_TCP {
-				return "", &UnsupportedMultiaddrError{URL: url}
+				return "", &UnsupportedMultiaddrError{URL: ipfsUrl}
 			}
 
 			// check if scheme is present
 			if index == 2 {
 				if component.Protocol().Code != ma.P_HTTP && component.Protocol().Code != ma.P_HTTPS {
-					return "", &UnsupportedMultiaddrError{URL: url}
+					return "", &UnsupportedMultiaddrError{URL: ipfsUrl}
 				}
 
 				parts = append(parts, component.Protocol().Name)
@@ -160,22 +163,37 @@ func ParseMultiAddrURL(url string) (string, error) {
 		}
 
 		if len(parts) < 2 {
-			return "", &UnsupportedMultiaddrError{URL: url}
+			return "", &UnsupportedMultiaddrError{URL: ipfsUrl}
 		}
 
 		// join host and port
-		url = net.JoinHostPort(parts[0], parts[1])
+		ipfsUrl = net.JoinHostPort(parts[0], parts[1])
 
 		// add scheme if present
 		if len(parts) >= 3 {
-			url = fmt.Sprintf("%s://%s", parts[2], url)
+			ipfsUrl = fmt.Sprintf("%s://%s", parts[2], ipfsUrl)
 		} else {
-			url = fmt.Sprintf("http://%s", url) // default to http if scheme is not present
+			ipfsUrl = fmt.Sprintf("http://%s", ipfsUrl) // default to http if scheme is not present
+		}
+	} else {
+		// parse http url
+		parsedURL, err := url.ParseRequestURI(ipfsUrl)
+		if err != nil {
+			return "", err
+		}
+
+		// check if scheme is http or https
+		if !strings.EqualFold(parsedURL.Scheme, "http") && !strings.EqualFold(parsedURL.Scheme, "https") {
+			return "", fmt.Errorf("unsupported scheme: %s", parsedURL.Scheme)
+		}
+
+		// check if host is present
+		if parsedURL.Host == "" {
+			return "", errors.New("host is required in url")
 		}
 	}
 
-	// return url as it is, invalid url will be caught while initializing ipfs client
-	return url, nil
+	return ipfsUrl, nil
 }
 
 func (client *IpfsClient) UploadSnapshotToIPFS(payloadCommit *datamodel.PayloadCommitMessage) error {

--- a/go/goutils/ipfsutils/ipfs_utils.go
+++ b/go/goutils/ipfsutils/ipfs_utils.go
@@ -127,6 +127,7 @@ func (e *UnsupportedMultiaddrError) Error() string {
 	return fmt.Sprintf("unsupported multiaddr url pattern: %s", e.URL)
 }
 
+// ParseMultiAddrURL tries to parse a multiaddr URL, if the url is not multiaddr it returns url as it is
 func ParseMultiAddrURL(url string) (string, error) {
 	parts := make([]string, 0) // [host,port,scheme]
 
@@ -171,10 +172,9 @@ func ParseMultiAddrURL(url string) (string, error) {
 		} else {
 			url = fmt.Sprintf("http://%s", url) // default to http if scheme is not present
 		}
-	} else {
-		return "", err
 	}
 
+	// return url as it is, invalid url will be caught while initializing ipfs client
 	return url, nil
 }
 


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Removes strict check for valid multiaddr URL and allows http url as well

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.

### Current behaviour
if IPFS client URL is not a valid multiaddr format, client initialization fails 

### New expected behaviour
Both multiaddr URL and HTTP URL are supported

`valid URLs`:
- /dns/localhost/tcp/5001
- /dns/ipfs.infura.io/tcp/5001/https
- http://localhost:5001
- https://ipfs.infura.io:5001

`invalid URLs`:
- /dns/localhost/udp/5001
- localhost:5001
- ipfs.infura.io:5001

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->

## Deployment Instructions
NA