### PR TITLE
Publishing snapshot submitted event through Rabbitmq

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ethereum/go-ethereum v1.11.6
 	github.com/go-playground/validator/v10 v10.14.0
 	github.com/go-redis/redis/v8 v8.11.5
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-ipfs-api v0.6.0
@@ -35,7 +36,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/holiman/uint256 v1.2.2-0.20230321075855-87b91420868c // indirect

--- a/go/goutils/datamodel/data_model.go
+++ b/go/goutils/datamodel/data_model.go
@@ -90,3 +90,11 @@ type SnapshotterIssue struct {
 	TimeOfReporting string `json:"timeOfReporting"`
 	Extra           string `json:"extra"`
 }
+
+type SnapshotSubmittedEventMessage struct {
+	SnapshotCid string `json:"snapshotCid"`
+	EpochId     int    `json:"epochId"`
+	ProjectId   string `json:"projectId"`
+	BroadcastId string `json:"broadcastId"`
+	Timestamp   int64  `json:"timestamp"`
+}

--- a/go/goutils/settings/settings.go
+++ b/go/goutils/settings/settings.go
@@ -38,11 +38,16 @@ type (
 			Core struct {
 				Exchange              string `json:"exchange"`
 				CommitPayloadExchange string `json:"commit_payload_exchange"`
+				EventDetectorExchange string `json:"event_detector_exchange"`
 			} `json:"core"`
 			PayloadCommit struct {
 				QueueNamePrefix  string `json:"queue_name_prefix"`
 				RoutingKeyPrefix string `json:"routing_key_prefix"`
 			} `json:"payload_commit"`
+			EventDetector struct {
+				QueueNamePrefix  string `json:"queue_name_prefix"`
+				RoutingKeyPrefix string `json:"routing_key_prefix"`
+			} `json:"event_detector"`
 		} `json:"setup"`
 	}
 

--- a/go/goutils/taskmgr/taskmgr.go
+++ b/go/goutils/taskmgr/taskmgr.go
@@ -10,16 +10,16 @@ import (
 )
 
 const (
-	TaskSuffix      string = "task"
-	DataSuffix      string = ".Data"
-	FinalizedSuffix string = ".Finalized"
-	DLXSuffix       string = "dlx"
+	TaskSuffix        string = "task"
+	DataSuffix        string = ".Data"
+	FinalizedSuffix   string = ".Finalized"
+	SnapshotSubmitted string = ".SnapshotSubmitted"
 )
 
 // TaskMgr interface is used to publish and consume tasks.
 // can be implemented by rabbitmq, kafka, webhooks etc.
 type TaskMgr interface {
-	Publish(ctx context.Context) error
+	Publish(ctx context.Context, workerType worker.Type, msg []byte) error
 
 	// Consume creates a new consumer and starts consuming tasks.
 	// as this method can be implemented by different task managers, we need to pass config for consumer initialization.

--- a/go/goutils/taskmgr/worker/worker.go
+++ b/go/goutils/taskmgr/worker/worker.go
@@ -8,4 +8,5 @@ type Type string
 
 const (
 	TypePayloadCommitWorker Type = "payload-commit-worker"
+	TypeEventDetectorWorker Type = "event-detector-worker"
 )

--- a/go/payload-commit/service/service.go
+++ b/go/payload-commit/service/service.go
@@ -15,12 +15,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+	"github.com/google/uuid"
 	"github.com/hashicorp/go-retryablehttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/swagftw/gi"
@@ -34,6 +36,8 @@ import (
 	contractApi "audit-protocol/goutils/smartcontract/api"
 	"audit-protocol/goutils/smartcontract/transactions"
 	"audit-protocol/goutils/taskmgr"
+	rabbitmqMgr "audit-protocol/goutils/taskmgr/rabbitmq"
+	"audit-protocol/goutils/taskmgr/worker"
 	w3storage "audit-protocol/goutils/w3s"
 	"audit-protocol/payload-commit/signer"
 )
@@ -52,6 +56,8 @@ type PayloadCommitService struct {
 	privKey       *ecdsa.PrivateKey
 	issueReporter *reporting.IssueReporter
 	httpClient    *retryablehttp.Client
+	taskMgr       *rabbitmqMgr.RabbitmqTaskMgr
+	uuid          uuid.UUID
 }
 
 // InitPayloadCommitService initializes the payload commit service.
@@ -96,6 +102,11 @@ func InitPayloadCommitService(reporter *reporting.IssueReporter) *PayloadCommitS
 		log.WithError(err).Fatal("failed to get private key")
 	}
 
+	taskMgr, err := gi.Invoke[*rabbitmqMgr.RabbitmqTaskMgr]()
+	if err != nil {
+		log.WithError(err).Fatal("failed to invoke task manager")
+	}
+
 	pcService := &PayloadCommitService{
 		settingsObj:   settingsObj,
 		redisCache:    redisCache,
@@ -108,6 +119,8 @@ func InitPayloadCommitService(reporter *reporting.IssueReporter) *PayloadCommitS
 		privKey:       privKey,
 		issueReporter: reporter,
 		httpClient:    httpclient.GetDefaultHTTPClient(settingsObj.HttpClient.ConnectionTimeout),
+		taskMgr:       taskMgr,
+		uuid:          uuid.New(),
 	}
 
 	_ = pcService.initLocalCachedData()
@@ -269,6 +282,33 @@ func (s *PayloadCommitService) HandlePayloadCommitTask(msg *datamodel.PayloadCom
 			return err
 		}
 	}
+
+	// publish snapshot submitted event
+	go func() {
+		eventMsg := &datamodel.SnapshotSubmittedEventMessage{
+			SnapshotCid: msg.SnapshotCID,
+			EpochId:     msg.EpochID,
+			ProjectId:   msg.ProjectID,
+			BroadcastId: s.uuid.String(),
+			Timestamp:   time.Now().Unix(),
+		}
+
+		msgBytes, err := json.Marshal(eventMsg)
+		if err != nil {
+			log.WithError(err).Error("failed to marshal snapshot submitted event message")
+
+			return
+		}
+
+		err = s.taskMgr.Publish(context.Background(), worker.TypeEventDetectorWorker, msgBytes)
+		if err != nil {
+			log.WithField("msg", string(msgBytes)).WithError(err).Error("failed to publish snapshot submitted event message")
+
+			return
+		}
+
+		log.Info("published snapshot submitted event message")
+	}()
 
 	// store unfinalized payload cid in redis
 	err = s.redisCache.AddUnfinalizedSnapshotCID(context.Background(), msg)

--- a/settings.example.json
+++ b/settings.example.json
@@ -20,11 +20,16 @@
     "setup": {
       "core": {
         "commit_payload_exchange": "powerloom-backend-commit-payload:",
-        "exchange": "audit-protocol-backend"
+        "exchange": "audit-protocol-backend",
+        "event_detector_exchange": "powerloom-backend-event-detector:"
       },
       "payload_commit": {
         "queue_name_prefix": "powerloom-backend-commit-payload-queue:",
         "routing_key_prefix": "powerloom-backend-commit-payload:"
+      },
+      "event_detector": {
+          "queue_name_prefix": "powerloom-event-detector:",
+          "routing_key_prefix": "powerloom-event-detector:"
       }
     }
   },


### PR DESCRIPTION
Publishing `snapshot submitted` event  through Rabbitmq, when a snapshot is submitted to contract.

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.

### Current behaviour
When a snapshot is submitted to the PowerLoom smart contract. Contract emits `SnapshotSubmmited` event.

### New expected behaviour
When Payload commit service submits snapshot to the contract, now it also publishes `Snapshot submitted` event through RabbitMQ, which is then consumed by Event Detector running inside Pooler.

*NOTE: Payload commit service is mimicking the behaviour of the smart contract event mentioned above, so that aggregate projects that are dependent on a project's submission can go ahead with their calculation, considering the worst case scenario where the transaction relayer fails to submit the snapshot for consensus to the protocol state smart contract.*

## Deployment Instructions
Please check the `settings.example.json` file for config changes
