### PR TITLE
Hotfix: disable retries on HTTP requests

### DIFF
--- a/go/goutils/httpclient/http_client.go
+++ b/go/goutils/httpclient/http_client.go
@@ -43,7 +43,7 @@ func GetDefaultHTTPClient(timeout int) *retryablehttp.Client {
 	}
 
 	retryableHTTPClient := retryablehttp.NewClient()
-	retryableHTTPClient.RetryMax = 5
+	retryableHTTPClient.RetryMax = 0
 	retryableHTTPClient.HTTPClient = rawHTTPClient
 	retryableHTTPClient.Logger = log.StandardLogger()
 


### PR DESCRIPTION

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
Presently the Audit Protocol services use a retryable HTTP package which is redundant and often over consumes resources along with causing memory leakage issues.

### New expected behaviour
<!-- Describe the new code and its expected behaviour -->

HTTP requests are not retried since the components which handle them have built in redundancy, load balancing and retires.


## Deployment Instructions
NA
